### PR TITLE
Unified with hydrate

### DIFF
--- a/public/components/bit-os-projects/bit-os-projects.stache
+++ b/public/components/bit-os-projects/bit-os-projects.stache
@@ -10,7 +10,7 @@
 {{/each}}
 <tr>
 	<td colspan="4">
-		<a href="#" ($click)="toggleAddNewProject()">Add Project</a>
+		<a href="javascript://" ($click)="toggleAddNewProject()">Add Project</a>
 		{{#if adding}}
 		<div class="panel panel-default">
 			<div class="panel-heading">Add Project</div>

--- a/public/models/contribution-month.js
+++ b/public/models/contribution-month.js
@@ -12,21 +12,36 @@ var contributionMonthAlgebra = new set.Algebra(
     set.comparators.id("_id")
 );
 
+var makeOSProject = function(props){
+  if(props instanceof OSProject) {
+    return props;
+  } else {
+    return OSProject.connection.hydrateInstance(props);
+  }
+};
+var makeClientProject = function(props){
+  if(props instanceof ClientProject) {
+    return props;
+  } else {
+    return ClientProject.connection.hydrateInstance(props);
+  }
+};
+
 var MonthlyOSProject = DefineMap.extend("MonthlyOSProject",{
   osProjectId: "string",
   significance: "number",
   commissioned: "boolean",
-  osProject: { type: OSProject.connection.hydrateInstance.bind(OSProject.connection) }
+  osProject: { type: makeOSProject }
 });
 
 var MonthlyClientProjectsOsProject = DefineMap.extend("MonthlyClientProjectOsProject",{
     osProjectId: "123123sdfasdf",
-    osProject: {type: OSProject.connection.hydrateInstance.bind(OSProject.connection) }
+    osProject: {type: makeOSProject }
 });
 
 var MonthlyClientProject = DefineMap.extend("MonthlyClientProject",{
   clientProjectId: "string",
-  clientProject: ClientProject,
+  clientProject: {type: makeClientProject},
   hours: "number",
   monthlyClientProjectsOsProjects: {Type: [MonthlyClientProjectsOsProject]},
 });

--- a/public/models/test.js
+++ b/public/models/test.js
@@ -3,6 +3,7 @@ import './fixtures/';
 import QUnit from "steal-qunit";
 import ContributionMonth from "./contribution-month";
 import ClientProject from "./client-project";
+import OSProject from "./os-project";
 
 QUnit.module("models");
 
@@ -17,4 +18,39 @@ QUnit.asyncTest("getList of ContributionMonth", function() {
 	}, function(err) {
 		debugger;
 	});
+});
+
+QUnit.test("make type convert able to accept instances (#23)", function() {
+	var osProject = new OSProject({
+			_id: "somethingCrazey",
+			name: "CanJS"
+	});
+
+	var clientProject = new ClientProject({
+			_id: "asl;dfal;sfj ;lakwj",
+			name: "HualHound"
+	});
+
+	var contributionMonth = new ContributionMonth({
+			_id: "aslkfalsjklas",
+			date: 124234211310000,
+			monthlyOSProjects: [{
+					significance: 80,
+					commissioned: true,
+					osProjectId: osProject._id,
+					osProject: osProject
+			}],
+			monthlyClientProjects: [{
+					monthlyClientProjectsOsProjects: [{
+							osProjectId: osProject._id,
+							osProject: osProject
+					}],
+					hours: 100,
+					clientProjectId: clientProject._id,
+					clientProject: clientProject
+			}]
+	});
+
+	QUnit.equal(contributionMonth.monthlyOSProjects[0].osProject.name , "CanJS")
+
 });


### PR DESCRIPTION
for #23 

Changes the contributor month type converters to first check if the passed property is already an instance of the desired type.  If it is, it leaves it alone.