### PR TITLE
docs(Travis Badge): Point travis-badge at staging

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Royalties
 
-[![Build Status](https://travis-ci.org/donejs/bitcentive.svg?branch=master)](https://travis-ci.org/donejs/bitcentive)
+[![Build Status](https://travis-ci.org/donejs/bitcentive.svg?branch=staging)](https://travis-ci.org/donejs/bitcentive)
 
 ## About
 


### PR DESCRIPTION
This will show the status of the build during development, which is done on the staging branch, not just the master branch, where presumably things have been QA'd