### PR TITLE
Clean up models and fixtues for DRYness and consistency

### DIFF
--- a/public/models/algebras/contribution-month.js
+++ b/public/models/algebras/contribution-month.js
@@ -1,0 +1,22 @@
+import set from "can-set";
+import moment from "moment";
+
+export default new set.Algebra(
+  set.comparators.id("_id"),
+  set.comparators.sort("$sort", function($sort, cm1, cm2){
+    if($sort.date) {
+      if(parseInt($sort.date) === 1) {
+        return moment(cm1.date).toDate() - moment(cm2.date).toDate();
+      } else {
+        return moment(cm2.date).toDate() - moment(cm1.date).toDate();
+      }
+    } else {
+      throw "can't sort that way";
+    }
+  }),
+  {
+    "$populate": function(){
+      return true;
+    }
+  }
+);

--- a/public/models/algebras/id-comparator.js
+++ b/public/models/algebras/id-comparator.js
@@ -1,0 +1,11 @@
+/**
+ * Most models use a simple "_id" comparator algebra. As soon as a model
+ * needs a more complex algebra, create a new algebra file for that model.
+ * Make sure to update both the model and the fixture to use the new algebra!
+ */
+
+import set from 'can-set';
+
+export default new set.Algebra(
+  set.comparators.id("_id")
+);

--- a/public/models/algebras/id-comparator.js
+++ b/public/models/algebras/id-comparator.js
@@ -7,5 +7,5 @@
 import set from 'can-set';
 
 export default new set.Algebra(
-  set.comparators.id("_id")
+  set.props.id("_id")
 );

--- a/public/models/client-project.js
+++ b/public/models/client-project.js
@@ -2,33 +2,11 @@ import DefineMap from 'can-define/map/';
 import DefineList from 'can-define/list/';
 import set from 'can-set';
 
-import feathersClient from './feathers';
-import connect from 'can-connect';
 import feathersBehavior from 'can-connect-feathers';
-import dataParse from 'can-connect/data/parse/';
-import construct from 'can-connect/constructor/';
-import constructStore from 'can-connect/constructor/store/';
-import constructOnce from 'can-connect/constructor/callbacks-once/';
-import canMap from 'can-connect/can/map/';
-import canRef from 'can-connect/can/ref/';
-import dataCallbacks from 'can-connect/data/callbacks/';
-import realtime from 'can-connect/real-time/';
+import feathersClient from './feathers';
+import superModel from './super-model';
 
-var behaviorList = [
-  dataParse,
-  construct,
-  constructStore,
-  constructOnce,
-  canMap,
-  canRef,
-  dataCallbacks,
-  realtime,
-  feathersBehavior
-];
-
-var clientProjectAlgebra = new set.Algebra(
-  set.comparators.id('_id')
-);
+import clientProjectAlgebra from './algebras/id-comparator';
 
 var ClientProject = DefineMap.extend({
   _id: 'string',
@@ -39,16 +17,14 @@ ClientProject.List = DefineList.extend({
   "*": ClientProject
 });
 
-ClientProject.connection = connect(behaviorList, {
+ClientProject.connection = superModel([feathersBehavior], {
   parseInstanceProp: "data",
   Map: ClientProject,
   List: ClientProject.List,
   feathersService: feathersClient.service('/api/client_projects'),
   name: "client-projects",
-  algebra: clientProjectAlgebra,
-  idProp: "_id"
+  algebra: clientProjectAlgebra
 });
-
 ClientProject.algebra = clientProjectAlgebra;
 
 export default ClientProject;

--- a/public/models/contribution-month.js
+++ b/public/models/contribution-month.js
@@ -2,60 +2,19 @@ import ClientProject from "./client-project";
 import OSProject from "./os-project";
 import Contributor from "./contributor";
 
-import set from "can-set";
 import DefineMap from "can-define/map/";
 import DefineList from "can-define/list/";
 
 import "../lib/prefilter";
-import moment from "moment";
 import MonthlyOSProject from "./monthly-os-project";
 import MonthlyClientProject from "./monthly-client-project";
 import MonthlyContributions from "./monthly-contributions";
 
-import feathersClient from './feathers';
-import connect from 'can-connect';
 import feathersBehavior from 'can-connect-feathers';
-import dataParse from 'can-connect/data/parse/';
-import construct from 'can-connect/constructor/';
-import constructStore from 'can-connect/constructor/store/';
-import constructOnce from 'can-connect/constructor/callbacks-once/';
-import canMap from 'can-connect/can/map/';
-import canRef from 'can-connect/can/ref/';
-import dataCallbacks from 'can-connect/data/callbacks/';
-import realtime from 'can-connect/real-time/';
+import feathersClient from './feathers';
+import superModel from './super-model';
 
-var behaviorList = [
- feathersBehavior,
- dataParse,
- construct,
- constructStore,
- canMap,
- canRef,
- realtime,
- dataCallbacks,
- constructOnce
-];
-
-var contributionMonthAlgebra = new set.Algebra(
-  set.comparators.id("_id"),
-  set.comparators.sort("$sort", function($sort, cm1, cm2){
-    if($sort.date) {
-      if(parseInt($sort.date) === 1) {
-        return moment(cm1.date).toDate() - moment(cm2.date).toDate();
-      } else {
-        return moment(cm2.date).toDate() - moment(cm1.date).toDate();
-      }
-    } else {
-      throw "can't sort that way";
-    }
-
-  }),
-  {
-    "$populate": function(){
-      return true;
-    }
-  }
-);
+import contributionMonthAlgebra from './algebras/contribution-month';
 
 var ContributionMonth = DefineMap.extend("ContributionMonth",{
   _id: "string",
@@ -233,18 +192,18 @@ var dataMassage = function(oType) {
   };
 };
 
-ContributionMonth.connection = connect(behaviorList, {
+ContributionMonth.List = DefineList.extend({
+  "*": ContributionMonth
+});
+
+ContributionMonth.connection = superModel([feathersBehavior], {
   parseInstanceProp: "data",
-  idProp: "_id",
   Map: ContributionMonth,
   List: ContributionMonth.List,
   feathersService: feathersClient.service("/api/contribution_months"),
-  // url: "/api/contribution_months",
   name: "contributionMonth",
   algebra: contributionMonthAlgebra
 });
 ContributionMonth.algebra = contributionMonthAlgebra;
 
 export default ContributionMonth;
-
-export { contributionMonthAlgebra as algebra };

--- a/public/models/contributor.js
+++ b/public/models/contributor.js
@@ -1,30 +1,11 @@
 import DefineMap from "can-define/map/";
 import DefineList from "can-define/list/";
-import set from "can-set";
 
-import feathersClient from './feathers';
-import connect from 'can-connect';
 import feathersBehavior from 'can-connect-feathers';
-import dataParse from 'can-connect/data/parse/';
-import construct from 'can-connect/constructor/';
-import constructStore from 'can-connect/constructor/store/';
-import constructOnce from 'can-connect/constructor/callbacks-once/';
-import canMap from 'can-connect/can/map/';
-import canRef from 'can-connect/can/ref/';
-import dataCallbacks from 'can-connect/data/callbacks/';
-import realtime from 'can-connect/real-time/';
+import feathersClient from './feathers';
+import superModel from './super-model';
 
-var behaviorList = [
-  dataParse,
-  construct,
-  constructStore,
-  constructOnce,
-  canMap,
-  canRef,
-  dataCallbacks,
-  realtime,
-  feathersBehavior
-];
+import contributorAlgebra from './algebras/id-comparator';
 
 var Contributor = DefineMap.extend("Contributor", {
   _id: "string",
@@ -33,20 +14,16 @@ var Contributor = DefineMap.extend("Contributor", {
   active: "boolean"
 });
 
-var contributorAlgebra = new set.Algebra(
-  set.comparators.id("_id")
-);
-
 Contributor.List = DefineList.extend({
   "*": Contributor
 });
 
-Contributor.connection = connect(behaviorList, {
-  idProp: "_id",
+Contributor.connection = superModel([feathersBehavior], {
   Map: Contributor,
   List: Contributor.List,
   feathersService: feathersClient.service("/api/contributors"),
   name: "contributor",
+  algebra: contributorAlgebra,
 });
 Contributor.algebra = contributorAlgebra;
 

--- a/public/models/fixtures/client-project.js
+++ b/public/models/fixtures/client-project.js
@@ -1,8 +1,7 @@
 import fixture from 'can-fixture';
 import json from './client-projects.json';
-//import { algebra } from '../client-project';
-import canSet from 'can-set';
-var algebra = new canSet.Algebra(canSet.props.id('_id'));
+
+import algebra from '../algebras/id-comparator';
 
 var store = fixture.store(json, algebra);
 

--- a/public/models/fixtures/contribution-months.js
+++ b/public/models/fixtures/contribution-months.js
@@ -1,10 +1,7 @@
 import fixture from 'can-fixture';
 import json from './contribution-months.json';
 
-// Can't import algebra from the model since it will initiate connection.
-//import { algebra } from '../contribution-month';
-import canSet from 'can-set';
-var algebra = new canSet.Algebra(canSet.props.id('_id'));
+import algebra from '../algebras/contribution-month';
 
 export var store = fixture.store(json, algebra);
 

--- a/public/models/fixtures/contributor.js
+++ b/public/models/fixtures/contributor.js
@@ -1,7 +1,6 @@
 import fixture from 'can-fixture';
-//import Contributor from '../contributor';
-import canSet from 'can-set';
-var algebra = new canSet.Algebra(canSet.props.id('_id'));
+
+import algebra from '../algebras/id-comparator';
 
 var store = fixture.store([{
     _id: "1-JustinMeyer",

--- a/public/models/fixtures/os-project.js
+++ b/public/models/fixtures/os-project.js
@@ -1,8 +1,7 @@
 import fixture from 'can-fixture';
 import json from './os-projects.json';
-//import { algebra } from '../os-project';
-import canSet from 'can-set';
-var algebra = new canSet.Algebra(canSet.props.id('_id'));
+
+import algebra from '../algebras/id-comparator';
 
 var store = fixture.store(json, algebra);
 

--- a/public/models/os-project.js
+++ b/public/models/os-project.js
@@ -1,42 +1,24 @@
-import set from "can-set";
 import DefineMap from "can-define/map/";
+import DefineList from "can-define/list/";
 
-import feathersClient from './feathers';
-import connect from 'can-connect';
 import feathersBehavior from 'can-connect-feathers';
-import dataParse from 'can-connect/data/parse/';
-import construct from 'can-connect/constructor/';
-import constructStore from 'can-connect/constructor/store/';
-import constructOnce from 'can-connect/constructor/callbacks-once/';
-import canMap from 'can-connect/can/map/';
-import canRef from 'can-connect/can/ref/';
-import dataCallbacks from 'can-connect/data/callbacks/';
-import realtime from 'can-connect/real-time/';
+import feathersClient from './feathers';
+import superModel from './super-model';
 
-var behaviorList = [
-  dataParse,
-  construct,
-  constructStore,
-  constructOnce,
-  canMap,
-  canRef,
-  dataCallbacks,
-  realtime,
-  feathersBehavior
-];
+import osProjectAlgebra from './algebras/id-comparator';
 
 var OSProject =  DefineMap.extend("OSProject", {
   _id: "string",
   name: "string"
 });
 
-var osProjectAlgebra = new set.Algebra(
-  set.comparators.id("_id")
-);
+OSProject.List = DefineList.extend({
+	"*": OSProject
+});
 
-OSProject.connection = connect(behaviorList, {
+OSProject.connection = superModel([feathersBehavior], {
   parseInstanceProp: "data",
-  idProp: "_id",
+  idProp: "_id", // TODO: removing this line causes tests to break - not sure why
   Map: OSProject,
   List: OSProject.List,
   feathersService: feathersClient.service("/api/os_projects"),

--- a/public/models/os-project.js
+++ b/public/models/os-project.js
@@ -18,7 +18,6 @@ OSProject.List = DefineList.extend({
 
 OSProject.connection = superModel([feathersBehavior], {
   parseInstanceProp: "data",
-  idProp: "_id", // TODO: removing this line causes tests to break - not sure why
   Map: OSProject,
   List: OSProject.List,
   feathersService: feathersClient.service("/api/os_projects"),

--- a/public/models/session.js
+++ b/public/models/session.js
@@ -1,36 +1,18 @@
 /* global window */
-import connect from 'can-connect';
 import DefineMap from 'can-define/map/';
 import DefineList from 'can-define/list/';
 import User from 'bitcentive/models/user';
 import canEvent from 'can-event';
 
+import superModel from './super-model';
 import feathersClient from './feathers';
 import feathersSession from 'can-connect-feathers/session';
-import dataParse from 'can-connect/data/parse/';
-import construct from 'can-connect/constructor/';
-import constructStore from 'can-connect/constructor/store/';
-import constructOnce from 'can-connect/constructor/callbacks-once/';
-import canMap from 'can-connect/can/map/';
-import canRef from 'can-connect/can/ref/';
-import dataCallbacks from 'can-connect/data/callbacks/';
-import realtime from 'can-connect/real-time/';
 import {authAgent} from 'authentication-popups';
 import decode from 'jwt-decode';
 
-var behaviorList = [
-  dataParse,
-  construct,
-  constructStore,
-  constructOnce,
-  canMap,
-  canRef,
-  dataCallbacks,
-  realtime,
-  feathersSession
-];
+import sessionAlgebra from './algebras/id-comparator';
 
-export const Session = DefineMap.extend('Session', {
+var Session = DefineMap.extend('Session', {
   seal: false
 }, {
   _id: '*',
@@ -53,18 +35,19 @@ Session.List = DefineList.extend({
   '*': Session
 });
 
-export const sessionConnection = connect(behaviorList, {
+Session.connection = superModel([feathersSession], {
   feathersClient,
-  idProp: '_id',
   Map: Session,
   List: Session.List,
-  name: 'session'
+  name: 'session',
+  algebra: sessionAlgebra,
 });
+Session.algebra = sessionAlgebra;
 
 Object.assign(Session, canEvent);
 window.authAgent.on('login', function (token) {
   let payload = decode(token);
-  sessionConnection.createInstance(payload);
+  Session.connection.createInstance(payload);
   Session.trigger('created', [payload]);
 });
 

--- a/public/models/signup.js
+++ b/public/models/signup.js
@@ -2,31 +2,13 @@
 import DefineMap from 'can-define/map/';
 import DefineList from 'can-define/list/';
 
-import feathersClient from './feathers';
-import connect from 'can-connect';
 import feathersBehavior from 'can-connect-feathers';
-import dataParse from 'can-connect/data/parse/';
-import construct from 'can-connect/constructor/';
-import constructStore from 'can-connect/constructor/store/';
-import constructOnce from 'can-connect/constructor/callbacks-once/';
-import canMap from 'can-connect/can/map/';
-import canRef from 'can-connect/can/ref/';
-import dataCallbacks from 'can-connect/data/callbacks/';
-import realtime from 'can-connect/real-time/';
+import feathersClient from './feathers';
+import superModel from './super-model';
 
-var behaviorList = [
-  dataParse,
-  construct,
-  constructStore,
-  constructOnce,
-  canMap,
-  canRef,
-  dataCallbacks,
-  realtime,
-  feathersBehavior
-];
+import signupAlgebra from './algebras/id-comparator';
 
-export const Signup = DefineMap.extend('Signup', {
+var Signup = DefineMap.extend('Signup', {
   _id: '*',
   email: 'string',
   password: 'string'
@@ -36,13 +18,14 @@ Signup.List = DefineList.extend({
   '*': Signup
 });
 
-export const signupConnection = connect(behaviorList, {
+Signup.connection = superModel([feathersBehavior], {
   parseInstanceProp: 'data',
   feathersService: feathersClient.service('/signup'),
-  idProp: '_id',
   Map: Signup,
   List: Signup.List,
-  name: 'signup'
+  name: 'signup',
+  algebra: signupAlgebra
 });
+Signup.algebra = signupAlgebra;
 
 export default Signup;

--- a/public/models/super-model.js
+++ b/public/models/super-model.js
@@ -1,0 +1,34 @@
+import connect from 'can-connect';
+import dataParse from 'can-connect/data/parse/';
+import construct from 'can-connect/constructor/';
+import constructStore from 'can-connect/constructor/store/';
+import constructOnce from 'can-connect/constructor/callbacks-once/';
+import canMap from 'can-connect/can/map/';
+import canRef from 'can-connect/can/ref/';
+import dataCallbacks from 'can-connect/data/callbacks/';
+import realtime from 'can-connect/real-time/';
+
+const superModel = function(newBehaviors, options) {
+	if(arguments.length === 1) {
+		options = newBehaviors;
+	}
+
+	const behaviors = [
+		dataParse,
+		construct,
+		constructStore,
+		constructOnce,
+		canMap,
+		canRef,
+		dataCallbacks,
+		realtime
+	];
+
+	if(arguments.length === 2) {
+		Array.prototype.unshift.apply(behaviors, newBehaviors);
+	}
+
+	return connect(behaviors, options);
+};
+
+export default superModel;

--- a/public/models/super-model.js
+++ b/public/models/super-model.js
@@ -13,6 +13,10 @@ const superModel = function(newBehaviors, options) {
 		options = newBehaviors;
 	}
 
+	// TODO: remove this when this issue is closed:
+	// https://github.com/canjs/can-connect/issues/100
+	options.idProp = "_id";
+
 	const behaviors = [
 		dataParse,
 		construct,
@@ -25,7 +29,7 @@ const superModel = function(newBehaviors, options) {
 	];
 
 	if(arguments.length === 2) {
-		Array.prototype.unshift.apply(behaviors, newBehaviors);
+		Array.prototype.push.apply(behaviors, newBehaviors);
 	}
 
 	return connect(behaviors, options);

--- a/public/models/user.js
+++ b/public/models/user.js
@@ -2,33 +2,11 @@ import set from "can-set";
 import DefineMap from 'can-define/map/';
 import DefineList from 'can-define/list/list';
 
-import feathersClient from './feathers';
-import connect from 'can-connect';
 import feathersBehavior from 'can-connect-feathers';
-import dataParse from 'can-connect/data/parse/';
-import construct from 'can-connect/constructor/';
-import constructStore from 'can-connect/constructor/store/';
-import constructOnce from 'can-connect/constructor/callbacks-once/';
-import canMap from 'can-connect/can/map/';
-import canRef from 'can-connect/can/ref/';
-import dataCallbacks from 'can-connect/data/callbacks/';
-import realtime from 'can-connect/real-time/';
+import feathersClient from './feathers';
+import superModel from './super-model';
 
-var behaviorList = [
-  dataParse,
-  construct,
-  constructStore,
-  constructOnce,
-  canMap,
-  canRef,
-  dataCallbacks,
-  realtime,
-  feathersBehavior
-];
-
-var userAlgebra = new set.Algebra(
-    set.comparators.id("_id")
-);
+import userAlgebra from './algebras/id-comparator';
 
 var User = DefineMap.extend("User", {
   _id: "string",
@@ -42,15 +20,13 @@ var User = DefineMap.extend("User", {
 
 User.List = DefineList.extend({"*": User});
 
-User.connection = connect(behaviorList, {
-  idProp: "_id",
+User.connection = superModel([feathersBehavior], {
   Map: User,
   List: User.List,
   feathersService: feathersClient.service("/api/users"),
   name: "users",
   algebra: userAlgebra
 });
-
 User.algebra = userAlgebra;
 
 export default User;


### PR DESCRIPTION
This cleans up a lot of boilerplate in the models. It also makes things consistent across all models as there were discrepancies throughout. This also separates algebras so that they can be shared between connections and fixtures without stepping on each others toes.

I went ahead and did this because I wanted to eliminate any potential issues that may have been caused by inconsistencies. It already fixed an issue I was experiencing on my end where creating new content (such as an OS project or Client project) caused all content on the page to disappear. 