### PR TITLE
test: dont connect mongoose to mongod for tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "node": ">= 0.12.0"
   },
   "scripts": {
-    "test": "npm run jshint && npm run mocha && cd public && npm run test",
+    "test": "npm run jshint && TESTING=true npm run mocha && cd public && npm run test",
     "jshint": "jshint src/. test/. --config",
     "develop": "node src/ --develop",
     "start": "node src/",

--- a/public/models/fixtures/fixtures-socket.js
+++ b/public/models/fixtures/fixtures-socket.js
@@ -1,4 +1,4 @@
-import io from 'socket.io-client/socket.io';
+import io from 'socket.io-client';
 import fixtureSocket from 'can-fixture-socket';
 import mockContributionMonths from 'bitcentive/models/fixtures/contribution-months';
 import mockOsProjects from 'bitcentive/models/fixtures/os-project';

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -12,7 +12,9 @@ const user = require('./user');
 module.exports = function() {
   const app = this;
 
-  mongoose.connect(app.get('mongodb'));
+  if (process.env.TESTING !== 'true'){
+    mongoose.connect(app.get('mongodb'));
+  }
   mongoose.Promise = global.Promise;
 
   app.configure(authentication);


### PR DESCRIPTION
When test local or CI and mongo is not running then tests are failing because of trying to connect to mongo.