### PR TITLE
Prevent duplicates from being created at the service level

### DIFF
--- a/public/components/select-contribution-month/select-contribution-month.js
+++ b/public/components/select-contribution-month/select-contribution-month.js
@@ -34,7 +34,7 @@ export const ViewModel = DefineMap.extend({
   },
   contributionMonthsPromise: {
     get: function () {
-      return ContributionMonth.getList({});
+      return ContributionMonth.getList({$sort: {date: 1}});
     }
   },
 

--- a/src/services/contribution_month/hooks/index.js
+++ b/src/services/contribution_month/hooks/index.js
@@ -3,12 +3,14 @@
 const globalHooks = require('../../../hooks');
 const hooks = require('feathers-hooks');
 const auth = require('feathers-authentication').hooks;
+const validateRequestData = require('./validate-request-data');
 
 exports.before = {
   all: [
     auth.isAuthenticated(),
     // auth.checkPermissions({namespace: 'users', on: 'user', field: 'permissions'}),
     // auth.isPermitted()
+    validateRequestData()
   ],
   find: [],
   get: [],

--- a/src/services/contribution_month/hooks/validate-request-data.js
+++ b/src/services/contribution_month/hooks/validate-request-data.js
@@ -1,0 +1,61 @@
+"use strict";
+
+const errors = require('feathers-errors');
+
+/**
+ * Only allows for creation of unique months.
+ */
+const handleCreateRequest = function (hook) {
+	const ContributionMonth = this.Model;
+
+	if (!hook.data.date) {
+		return Promise.reject(new errors.BadRequest(`You must specify a date.`));
+	}
+
+	const postedDate = new Date(hook.data.date);
+	const postedMonth = postedDate.getMonth();
+	const postedYear = postedDate.getFullYear();
+	const nextMonth = postedMonth === 11 ? 0 : postedMonth + 1;
+	const nextYear = postedMonth === 11 ? 0 : postedYear + 1;
+	// Lower limit - beginning of month (ex: 2018-12-01T00:00:00Z)
+	const lowerLimit = new Date(Date.UTC(postedYear, postedMonth, 1));
+	// Upper limit - beginning of next month (ex: 2019-01-01T00:00:00Z)
+	const upperLimit = new Date(Date.UTC(nextMonth, nextYear, 1));
+
+	return new Promise((resolve, reject) => {
+		ContributionMonth.find({ 
+			"date": {
+				"$gte": lowerLimit,
+				"$lt": upperLimit
+			}
+		}).limit(1).exec((err, results) => {
+			if (err) {
+				return reject(err);
+			}
+			if (results.length) {
+				return reject(new errors.BadRequest(`Duplicate month - you cannot create two contribution months for the same month/year.`));
+			}
+			resolve(hook);
+		});
+	});
+};
+
+/**
+ * This hook is intended to be use on the "before" phase
+ * of any request to validate things.
+ */
+module.exports = function (options) {
+	return function (hook) {
+		let result;
+		switch (hook.method) {
+			case 'create':
+				result = handleCreateRequest.call(this, hook);
+				break;
+
+			default:
+				result = Promise.resolve(hook);
+				break;
+		}
+		return result;
+	};
+};

--- a/test/services/contribution_month/index.test.js
+++ b/test/services/contribution_month/index.test.js
@@ -2,9 +2,61 @@
 
 const assert = require('assert');
 const app = require('../../../src/app');
+const helpers = require('../helpers');
+const validateDataHook = require('../../../src/services/contribution_month/hooks/validate-request-data');
 
 describe('contribution_month service', function() {
   it('registered the contribution_months service', () => {
     assert.ok(app.service('/api/contribution_months'));
   });
+});
+
+describe('contribution_month validate data hook', function() {
+	const hookFn = validateDataHook();
+
+	it('does not allow duplicate months to be created', function(done) {
+		// The hook will attempt to load an existing month.
+		// If one exists, then the hook should fail.
+		const context = {
+			Model: helpers.createMockQueryObj([{
+				date: new Date()
+			}])
+		};
+
+		const promise = hookFn.call(context, {
+			method: 'create',
+			data: {
+				date: new Date()
+			}
+		});
+		promise.then(() => {
+			done(new Error('The hook allowed a duplicate'));
+		});
+		promise.catch(err => {
+			assert.ok(true, 'The hook prevented a duplicate');
+			done();
+		});
+	});
+
+	it('allows a new month to be created', function(done) {
+		// The hook will attempt to load an existing month.
+		// If none exist, the hook should succeed.
+		const context = {
+			Model: helpers.createMockQueryObj([/* return nothing */])
+		};
+
+		const promise = hookFn.call(context, {
+			method: 'create',
+			data: {
+				date: new Date()
+			}
+		});
+		promise.then(hook => {
+			assert.ok(true, 'The hook passed');
+			done();
+		});
+		promise.catch(err => {
+			done(new Error('The hook failed: ' + err));
+		});
+	});
 });

--- a/test/services/helpers.js
+++ b/test/services/helpers.js
@@ -1,0 +1,38 @@
+"use strict";
+
+/**
+ * Creates a mock mongoose Query object. The callback is called with the results.
+ * 
+ * Allows for both query conventions:
+ * 	- Model.find(params, callback)
+ * 	- Model.find(params).exec(callback)
+ * 	
+ * This works for Model.find, Model.findOne, and Model.findById requests
+ *
+ * @param      {Object|Array}  The result which should be returned by the query
+ * @return     {Mongoose.Query}  { A min }
+ */
+function createMockQueryObj(results) {
+	var queryObj = {};
+	['find', 'findOne'].forEach(method => {
+		queryObj[method] = function(...args) {
+			const lastArg = args[args.length - 1];
+			// allows for Model.find(params, callback) signature
+			if (typeof lastArg === 'function') {
+				return lastArg(null, results);
+			}
+
+			// allows for Model.find(params).limit(n).exec(callback) signature
+			['lean', 'distinct', 'sort', 'limit', 'select', 'where', 'equals', 'gt', 'gte', 'lt', 'lte', 'in'].forEach(method => {
+				queryObj[method] = function() { return this; };
+			});
+			queryObj.exec = function(cb) { cb(null, results); };
+			return this;
+		};
+	});
+	return queryObj;
+}
+
+module.exports = {
+	createMockQueryObj
+};


### PR DESCRIPTION
This closes #71 and also closes #81. This adds server side validation on ContributionMonth requests. 

- Adds default $sort and $limit if none are provided on FIND requests
- Prevents duplicates from being created