### PR TITLE
MonthlyMaps: Make ID maps a getter, code style clean up and ES6ify

### DIFF
--- a/public/models/client-project.js
+++ b/public/models/client-project.js
@@ -4,7 +4,7 @@ import set from 'can-set';
 import superModel from '../lib/super-model';
 import algebra from './algebras';
 
-var ClientProject = DefineMap.extend({
+var ClientProject = DefineMap.extend('ClientProject', {
   _id: 'string',
   name: 'string'
 });

--- a/public/models/contribution-month/monthly-client-project.js
+++ b/public/models/contribution-month/monthly-client-project.js
@@ -3,7 +3,7 @@ import DefineList from "can-define/list/";
 import MonthlyClientProjectsOsProject from "./monthly-client-projects-os-project";
 import ClientProject from "../client-project";
 
-var MonthlyClientProject = DefineMap.extend("MonthlyClientProject",{
+const MonthlyClientProject = DefineMap.extend( "MonthlyClientProject", {
   clientProjectRef: {
     type: ClientProject.Ref.type
   },
@@ -15,43 +15,28 @@ var MonthlyClientProject = DefineMap.extend("MonthlyClientProject",{
 });
 
 MonthlyClientProject.List = DefineList.extend({
-  "*": MonthlyClientProject,
-  monthlyProjectIdMap: {
-    get: function() {
-      var map = {};
-      this.forEach(function(monthlyClientProject, index) {
-        map[monthlyClientProject.clientProjectRef._id] = index;
-      });
-      return map;
-    }
+  "#": MonthlyClientProject,
+  has( clientProject ) {
+    return clientProject._id in this.monthlyClientProjectIdMap;
   },
-  has: function(clientProject) {
-    let monthlyClientProject;
-    if (!!clientProject._id) {
-      monthlyClientProject = new MonthlyClientProject({
-        clientProjectRef: clientProject._id,
-        clientProject: clientProject,
-        hours: 0
-      });
-    }
-    else {
-      monthlyClientProject = clientProject;
-    }
-    return monthlyClientProject.clientProjectRef._id in this.monthlyProjectIdMap;
-  },
-  toggleProject: function(clientProjectRef){
-    let monthlyClientProject = new MonthlyClientProject({
-        clientProjectRef: clientProjectRef._id,
-        clientProject: clientProjectRef,
+  toggleProject( clientProject ) {
+    const instance = this.monthlyClientProjectIdMap[clientProject._id];
+    if( instance ) {
+      this.splice(this.indexOf(instance), 1);
+    } else {
+      this.push( new MonthlyClientProject({
+        clientProjectRef: clientProject,
         hours: 0,
         monthlyClientProjectsOSProjects: []
-      });
-    var index =  this.monthlyProjectIdMap[monthlyClientProject.clientProjectRef._id];
-    if(index != null) {
-      this.splice(index, 1);
-    } else {
-      this.push(monthlyClientProject);
+      }) );
     }
+  },
+  get monthlyClientProjectIdMap() {
+    const map = {};
+    this.forEach( monthlyClientProject => {
+      map[monthlyClientProject.clientProjectRef._id] = monthlyClientProject;
+    });
+    return map;
   }
 });
 

--- a/public/models/contribution-month/monthly-client-projects-os-project.js
+++ b/public/models/contribution-month/monthly-client-projects-os-project.js
@@ -1,46 +1,34 @@
 import DefineMap from "can-define/map/";
 import DefineList from "can-define/list/";
-import OSProject  from "../os-project";
+import OSProject from "../os-project";
 import ClientProject from "../client-project";
 
-var MonthlyClientProjectsOsProject = DefineMap.extend("MonthlyClientProjectsOsProject",{
-    osProjectRef: {
-      type: OSProject.Ref.type
-    },
-    osProjectID: "number"
+const MonthlyClientProjectsOsProject = DefineMap.extend( "MonthlyClientProjectsOsProject", {
+  osProjectRef: {
+    type: OSProject.Ref.type
+  }
 });
 
 MonthlyClientProjectsOsProject.List = DefineList.extend({
-  "*": MonthlyClientProjectsOsProject,
-  osProjectIdMap: {
-    get: function(){
-      var map = {};
-      this.forEach(function(monthlyClientProjectOSProject, index){
-        map[monthlyClientProjectOSProject.osProjectRef._id] = index;
-      });
-      return map;
-    }
+  "#": MonthlyClientProjectsOsProject,
+  get osProjectIdMap() {
+    const map = {};
+    this.forEach( monthlyClientProjectOSProject => {
+      map[monthlyClientProjectOSProject.osProjectRef._id] = monthlyClientProjectOSProject;
+    });
+    return map;
   },
-  // serialize: function() {
-  //   let osProjectIds = [];
-  //   for(var i in this.osProjectIdMap) {
-  //     osProjectIds.push(i);
-  //   }
-  //   return osProjectIds;
-  // },
-  has: function(monthlyOsProject){
+  has( monthlyOsProject ){
     return monthlyOsProject.osProjectRef._id in this.osProjectIdMap;
   },
-  toggleProject: function(monthlyOSProject){
-    let newMonthlyOSProject = new MonthlyClientProjectsOsProject({
-      osProjectRef: monthlyOSProject.osProjectRef
-    });
-    var index = this.osProjectIdMap[newMonthlyOSProject.osProjectRef._id];
-
-    if(index != undefined) {
-      this.splice(index, 1);
+  toggleProject( monthlyOSProject ){
+    const monthlyClientProjectsOsProject = this.osProjectIdMap[monthlyOSProject.osProjectRef._id];
+    if( monthlyClientProjectsOsProject ) {
+      this.splice( this.indexOf(monthlyClientProjectsOsProject), 1);
     } else {
-      this.push(newMonthlyOSProject);
+      this.push( new MonthlyClientProjectsOsProject({
+        osProjectRef: monthlyOSProject.osProjectRef
+      }) );
     }
   },
 });

--- a/public/models/contribution-month/monthly-contributions.js
+++ b/public/models/contribution-month/monthly-contributions.js
@@ -3,7 +3,7 @@ import DefineList from "can-define/list/";
 import OSProject from "../os-project";
 import Contributor from "../contributor";
 
-var MonthlyContributions = DefineMap.extend("MonthlyContributions", {
+const MonthlyContributions = DefineMap.extend( "MonthlyContributions", {
   contributorRef: {
     type: Contributor.Ref.type
   },
@@ -15,7 +15,7 @@ var MonthlyContributions = DefineMap.extend("MonthlyContributions", {
 });
 
 MonthlyContributions.List = DefineList.extend({
-  "*": MonthlyContributions
+  "#": MonthlyContributions
 });
 
 export default MonthlyContributions;

--- a/public/models/contribution-month/monthly-os-project.js
+++ b/public/models/contribution-month/monthly-os-project.js
@@ -1,51 +1,39 @@
 import DefineMap from "can-define/map/";
 import DefineList from "can-define/list/";
-import OSProject from "../os-project";
-import ContributionMonth from "./contribution-month";
 import Observation from "can-observation";
 
-var MonthlyOSProject = DefineMap.extend("MonthlyOSProject",{
+import ContributionMonth from "./contribution-month";
+import OSProject from "../os-project";
+
+const MonthlyOSProject = DefineMap.extend( "MonthlyOSProject" , {
   significance: "number",
   commissioned: "boolean",
   osProjectRef: { type: OSProject.Ref.type },
-  osProjectID: "number",
   contributionMonth: {
     Type: ContributionMonth,
     serialize: false
-  },
-  init: function() {
-    if (!this.osProjectID && this.osProjectRef) {
-      this.osProjectID = this.osProjectRef._id;
-    }
   }
 });
 
 MonthlyOSProject.List = DefineList.extend({
   "#": {
     Type: MonthlyOSProject,
-    added: function(items) {
-      items.forEach(function(monthlyOSProject) {
+    added( items ) {
+      items.forEach( monthlyOSProject => {
         monthlyOSProject.contributionMonth = this.contributionMonth;
-        this.monthlyOSProjectIdMap[monthlyOSProject.osProjectID] = monthlyOSProject;
-      }, this);
+      } );
       return items;
     },
-    removed: function(items) {
-      items.forEach(function(monthlyOSProject) {
+    removed( items ) {
+      items.forEach( monthlyOSProject => {
         monthlyOSProject.contributionMonth = null;
-        this.monthlyOSProjectIdMap[monthlyOSProject.osProjectID] = null;
-      }, this);
+      } );
       return items;
     }
   },
-  init: function() {
-    this.forEach((monthlyOSProject) => {
-      this.monthlyOSProjectIdMap[monthlyOSProject.osProjectRef.id] = monthlyOSProject;
-    }, this);
-  },
   contributionMonth: {
-    set: function(contributionMonth) {
-      this.forEach(function(monthlyOSProject) {
+    set( contributionMonth ) {
+      this.forEach( monthlyOSProject => {
         monthlyOSProject.contributionMonth = contributionMonth;
       });
       return contributionMonth;
@@ -53,21 +41,22 @@ MonthlyOSProject.List = DefineList.extend({
     Type: ContributionMonth,
     serialize: false
   },
-  monthlyOSProjectIdMap: {
-    type: "any",
-    value: {}
-  },
-  has: function(osProject){
+  has( osProject ){
     return osProject._id in this.monthlyOSProjectIdMap;
   },
-  getSignificance: function(osProjectRef) {
-    var monthlyOSProject = this.monthlyOSProjectIdMap[osProjectRef._id];
+  getSignificance( osProjectRef ) {
+    const monthlyOSProject = this.monthlyOSProjectIdMap[osProjectRef._id];
     return monthlyOSProject ? monthlyOSProject.significance : false;
   },
-  commissioned: {
-    get: function(){
-      return this.filter({ commissioned: true });
-    }
+  get monthlyOSProjectIdMap() {
+    const map = {};
+    this.forEach( monthlyOSProject => {
+      map[monthlyOSProject.osProjectRef._id] = monthlyOSProject;
+    });
+    return map;
+  },
+  get commissioned() {
+    return this.filter({ commissioned: true });
   }
 });
 

--- a/public/models/contribution-month/test/monthly-client-project_test.js
+++ b/public/models/contribution-month/test/monthly-client-project_test.js
@@ -1,0 +1,55 @@
+import QUnit from 'steal-qunit';
+import OSProject from '../../os-project';
+import ClientProject from '../../client-project';
+import MonthlyClientProject from '../monthly-client-project';
+
+QUnit.module('models/monthly-os-project', () => {
+
+  QUnit.test('MonthlyClientProject basic test', function( assert ) {
+    const osProject = new OSProject({ _id: 'qwe123', name: 'DoneJS' });
+    const clientProject = new ClientProject({ _id: 'mxelplix12', name: 'Awesome Client' });
+
+    const monthlyClientProject = new MonthlyClientProject({
+      clientProjectRef: clientProject,
+      hours: 200,
+      monthlyClientProjectsOSProjects: [osProject]
+    });
+
+    assert.equal(monthlyClientProject.clientProjectRef._id, "mxelplix12", "clientProjectRef _id is correct");
+    assert.equal(monthlyClientProject.clientProjectRef.value.name, "Awesome Client", "clientProjectRef name is correct");
+  });
+
+  QUnit.module('MonthlyClientProject.List', {
+    beforeEach() {
+      this.CLIENT_PROJECT_ID = 'mxelplix12';
+      this.osProject = new OSProject({ _id: 'qwe123', name: 'DoneJS' });
+      this.clientProject = new ClientProject({ _id: this.CLIENT_PROJECT_ID, name: 'Awesome Client' });
+
+      this.monthlyClientProject = new MonthlyClientProject({
+        clientProjectRef: this.clientProject,
+        hours: 200,
+        monthlyClientProjectsOSProjects: [this.osProject]
+      });
+    }
+  },
+  function() {
+
+    QUnit.test(".has()", function( assert ){
+      const clientProject = this.clientProject;
+      const monthlyClientProject = this.monthlyClientProject;
+      const monthlyClientProjectsList = new MonthlyClientProject.List([monthlyClientProject]);
+      assert.ok(monthlyClientProjectsList.has( clientProject ), "has works as expected");
+    });
+
+    QUnit.test(".toggleProject()", function( assert ){
+      const clientProject = this.clientProject;
+      const monthlyClientProjectsList = new MonthlyClientProject.List();
+      monthlyClientProjectsList.toggleProject( clientProject );
+      assert.ok(monthlyClientProjectsList.has( clientProject ), "Has Project");
+      monthlyClientProjectsList.toggleProject( clientProject );
+      assert.notOk(monthlyClientProjectsList.has( clientProject ), "No longer Project");
+    });
+
+  });
+
+});

--- a/public/models/contribution-month/test/monthly-os-project_test.js
+++ b/public/models/contribution-month/test/monthly-os-project_test.js
@@ -4,7 +4,7 @@ import MonthlyOSProject from '../monthly-os-project';
 
 QUnit.module('models/monthly-os-project');
 
-QUnit.test('MonthlyOSProject basic test', function() {
+QUnit.test('MonthlyOSProject basic test', () => {
   let osProject = new OSProject({
     _id: 'qwe123',
     name: 'DoneJS'
@@ -16,13 +16,11 @@ QUnit.test('MonthlyOSProject basic test', function() {
     osProjectRef: osProject
   });
 
-  ok(monthlyOSProject.osProjectRef._id === "qwe123",
-    "osProjectRef _id is correct");
-  ok(monthlyOSProject.osProjectRef._value.name === "DoneJS",
-    "osProjectRef name is correct");
+  QUnit.ok(monthlyOSProject.osProjectRef._id === "qwe123", "osProjectRef _id is correct");
+  QUnit.ok(monthlyOSProject.osProjectRef._value.name === "DoneJS", "osProjectRef name is correct");
 });
 
-QUnit.test('MonthlyOSProject List basic test', function() {
+QUnit.test('MonthlyOSProject List basic test', () => {
   let osProject01 = new OSProject({
     _id: '1',
     name: 'DoneJS'
@@ -49,9 +47,7 @@ QUnit.test('MonthlyOSProject List basic test', function() {
   monthlyOSProjectsList.push(monthlyOSProject01);
   monthlyOSProjectsList.push(monthlyOSProject02);
 
-  ok(monthlyOSProjectsList.has(osProject01), "has works as expected");
-  ok(monthlyOSProjectsList.getSignificance(osProject01) === 1,
-    "getSignificance works as expected");
-  ok(monthlyOSProjectsList.commissioned.length === 1,
-    "got the right amount of commissioned")
+  QUnit.ok(monthlyOSProjectsList.has(osProject01), "has works as expected");
+  QUnit.ok(monthlyOSProjectsList.getSignificance(osProject01) === 1, "getSignificance works as expected");
+  QUnit.ok(monthlyOSProjectsList.commissioned.length === 1, "got the right amount of commissioned");
 });

--- a/public/test/test.js
+++ b/public/test/test.js
@@ -12,4 +12,5 @@ import 'bitcentive/components/register/register_test';
 
 import 'bitcentive/models/contribution-month/test/contribution-month_test';
 import 'bitcentive/models/contribution-month/test/monthly-os-project_test';
+import 'bitcentive/models/contribution-month/test/monthly-client-project_test';
 import 'bitcentive/models/os-project_test';


### PR DESCRIPTION
Resolves #136 
Made monthlyOSProjectIdMap and monthlyClientProjectIdMap a getter, removed setters and init
Clean up code styles
ES6ify - replace functions with arrows and object shorthand, vars with const, etc
Add 1 test file