### PR TITLE
Remove cookie-storage module

### DIFF
--- a/public/package.json
+++ b/public/package.json
@@ -62,7 +62,6 @@
     "can-view-autorender": "^3.0.1",
     "can-view-model": "^3.1.0",
     "can-zone": "^0.6.0",
-    "cookie-storage": "^1.0.4",
     "done-autorender": "^0.9.0-pre.1",
     "done-component": "^0.6.0-pre.2",
     "done-css": "^2.1.0-pre.0",


### PR DESCRIPTION
The cookie-storage module is no longer in use, so we should be able to take it out safely.  It was originally needed for the can-connect-feathers before it was refactored on top of feathers-client.

Closes https://github.com/donejs/bitcentive/issues/131