### PR TITLE
Use modal dialog for OS project selection

### DIFF
--- a/public/components/client-projects/client-projects-os-projects-modal.stache
+++ b/public/components/client-projects/client-projects-os-projects-modal.stache
@@ -1,0 +1,32 @@
+<div class="modal fade" id="os-project-modal" tabindex="-1" role="dialog" aria-hidden="true">
+  <div class="modal-dialog valign-center" role="document">
+    {{#with selectedClientProject}}
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+        <h4 class="modal-title">Monthy Client OS Projects</h4>
+      </div>
+      <div class="modal-body">
+        <ul class="os-project-list">
+        {{#each contributionMonth.monthlyOSProjects as monthlyOSProject}}
+          <li>
+            <input id="os_project_{{osProjectRef._id}}"
+                   type="checkbox"
+                   {{#if monthlyClientProjectsOSProjects.has(monthlyOSProject) }}checked{{/if}}
+                   value="{{osProjectRef.value.name}}"
+                   ($click)="toggleUseProject(monthlyClientProjectsOSProjects, monthlyOSProject)"
+                   {{#if contributionMonth.isSaving}} disabled{{/if}}/>
+            <label for="os_project_{{osProjectRef._id}}"
+                   {{#if commissioned}} class="commissioned" {{/if}}>
+              {{osProjectRef.value.name}}
+            </label>
+          </li>
+          {{/each}}
+        </ul>
+      </div>
+    </div>
+    {{/with}}
+  </div>
+</div>

--- a/public/components/client-projects/client-projects-os-projects-modal.stache
+++ b/public/components/client-projects/client-projects-os-projects-modal.stache
@@ -1,12 +1,12 @@
 <div class="modal fade" id="os-project-modal" tabindex="-1" role="dialog" aria-hidden="true">
   <div class="modal-dialog valign-center" role="document">
-    {{#with selectedClientProject}}
+    {{#if selectedClientProject}}
     <div class="modal-content">
       <div class="modal-header">
         <button type="button" class="close" data-dismiss="modal" aria-label="Close">
           <span aria-hidden="true">&times;</span>
         </button>
-        <h4 class="modal-title">Monthy Client OS Projects</h4>
+        <h4 class="modal-title">{{selectedClientProject.clientProjectRef.value.name}}: Monthy OS Projects</h4>
       </div>
       <div class="modal-body">
         <ul class="os-project-list">
@@ -14,10 +14,10 @@
           <li>
             <input id="os_project_{{osProjectRef._id}}"
                    type="checkbox"
-                   {{#if monthlyClientProjectsOSProjects.has(monthlyOSProject) }}checked{{/if}}
-                   value="{{osProjectRef.value.name}}"
-                   ($click)="toggleUseProject(monthlyClientProjectsOSProjects, monthlyOSProject)"
-                   {{#if contributionMonth.isSaving}} disabled{{/if}}/>
+                   {$checked}="selectedClientProject.monthlyClientProjectsOSProjects.has(monthlyOSProject)"
+                   {$value}="monthlyOSProject.osProjectRef.value.name"
+                   ($click)="toggleUseProject(selectedClientProject.monthlyClientProjectsOSProjects, monthlyOSProject)"
+                   {$disabled}="contributionMonth.isSaving"/>
             <label for="os_project_{{osProjectRef._id}}"
                    {{#if commissioned}} class="commissioned" {{/if}}>
               {{osProjectRef.value.name}}
@@ -27,6 +27,6 @@
         </ul>
       </div>
     </div>
-    {{/with}}
+    {{/if}}
   </div>
 </div>

--- a/public/components/client-projects/client-projects.html
+++ b/public/components/client-projects/client-projects.html
@@ -1,4 +1,6 @@
 <script type="text/stache" can-autorender id="demo">
+  <can-import from="jquery" />
+  <can-import from="bootstrap" />
   <can-import from="bootstrap/dist/css/bootstrap.css" />
   <can-import from="bitcentive/styles.less" />
   <can-import from="bitcentive/components/client-projects/" />

--- a/public/components/client-projects/client-projects.js
+++ b/public/components/client-projects/client-projects.js
@@ -1,4 +1,3 @@
-import stache from 'can-stache';
 import Component from 'can-component';
 import DefineMap from 'can-define/map/';
 import DefineList from 'can-define/list/list';
@@ -6,9 +5,6 @@ import './client-projects.less';
 import view from './client-projects.stache';
 import ClientProject from '../../models/client-project';
 import ContributionMonth from '../../models/contribution-month/';
-import osProjectsModal from './client-projects-os-projects-modal.stache';
-
-stache.registerPartial('os-projects-modal', osProjectsModal);
 
 export const ClientProjectVM = DefineMap.extend({
   // Passed properties

--- a/public/components/client-projects/client-projects.js
+++ b/public/components/client-projects/client-projects.js
@@ -21,9 +21,7 @@ export const ClientProjectVM = DefineMap.extend({
       return ClientProject.getList({});
     }
   },
-  selectedClientProject: {
-    Type: ClientProject
-  },
+  selectedClientProject: ClientProject,
   editingClientProjectIds: {
     Value: DefineMap.extend({seal: false},{}),
   },

--- a/public/components/client-projects/client-projects.js
+++ b/public/components/client-projects/client-projects.js
@@ -1,3 +1,4 @@
+import stache from 'can-stache';
 import Component from 'can-component';
 import DefineMap from 'can-define/map/';
 import DefineList from 'can-define/list/list';
@@ -5,6 +6,9 @@ import './client-projects.less';
 import view from './client-projects.stache';
 import ClientProject from '../../models/client-project';
 import ContributionMonth from '../../models/contribution-month/';
+import osProjectsModal from './client-projects-os-projects-modal.stache';
+
+stache.registerPartial('os-projects-modal', osProjectsModal);
 
 export const ClientProjectVM = DefineMap.extend({
   // Passed properties
@@ -16,6 +20,9 @@ export const ClientProjectVM = DefineMap.extend({
     value() {
       return ClientProject.getList({});
     }
+  },
+  selectedClientProject: {
+    Type: ClientProject
   },
   editingClientProjectIds: {
     Value: DefineMap.extend({seal: false},{}),
@@ -78,6 +85,9 @@ export const ClientProjectVM = DefineMap.extend({
       });
     }
     return promise;
+  },
+  setSelectedClientProject: function (clientProject) {
+    this.selectedClientProject = clientProject;
   },
   deleteClientProject: function(clientProject) {
     this.contributionMonth.removeClientProject(clientProject);

--- a/public/components/client-projects/client-projects.js
+++ b/public/components/client-projects/client-projects.js
@@ -87,22 +87,6 @@ export const ClientProjectVM = DefineMap.extend({
     monthlyClientProjectsOSProjects.toggleProject(monthlyOsProject);
     return this.contributionMonth.save();
   },
-  toggleEditMonthlyClientProject: function(monthlyClientProject) {
-    if( this.editingClientProjectIds.get(monthlyClientProject.clientProjectRef._id) ) {
-      this.editingClientProjectIds.set(monthlyClientProject.clientProjectRef._id, undefined);
-    } else {
-      this.editingClientProjectIds.set(monthlyClientProject.clientProjectRef._id, true);
-    }
-  },
-  setActiveOSProjectList: function(monthlyClientProject) {
-    this.activeOSProjectList = monthlyClientProject;
-  },
-  checkActiveOSProjectList: function(monthlyClientProject) {
-    return this.activeOSProjectList === monthlyClientProject;
-  },
-  isEditingMonthlyClientProject: function(monthlyClientProject){
-    return this.editingClientProjectIds.get(monthlyClientProject.clientProjectId);
-  },
 });
 
 export default Component.extend({

--- a/public/components/client-projects/client-projects.less
+++ b/public/components/client-projects/client-projects.less
@@ -1,7 +1,27 @@
 bit-client-projects {
 	display: block;
 
-  .hours-input {
-    width: 80px;
-  }
+	.hours-input {
+		width: 80px;
+	}
+	.os-projects-cell {
+		width: 50%;
+	}
+	.os-project-list {
+		list-style: none;
+		padding-left: 0;
+		margin-bottom: 0;
+	}
+	.selected-os-projects-list {
+		list-style: none;
+		padding-left: 0;
+
+		li {
+			display: inline-block;
+			background-color: #eee;
+			border: 1px solid #aaa;
+			padding-left: .5em;
+			border-radius: .3em;
+		}
+	}
 }

--- a/public/components/client-projects/client-projects.stache
+++ b/public/components/client-projects/client-projects.stache
@@ -21,7 +21,7 @@
                ($change)="save()"
                {{#if isSaving}} disabled {{/if}}/>
       </td>
-      <td ($mouseenter)="setActiveOSProjectList(monthlyClientProject)" ($mouseleave)="setActiveOSProjectList(null)">
+      <td class="os-projects-cell">
         {{! Count of commissioned projects }}
         {{commissionedMonthlyOSProjectsCountFor(monthlyClientProject)}} / {{monthlyOSProjects.commissioned.length}}
         +
@@ -29,22 +29,54 @@
         {{uncommissionedMonthlyOSProjectsCountFor(monthlyClientProject)}}
 
         {{! Toggle of OS projects }}
-        {{#if checkActiveOSProjectList(monthlyClientProject)}}
-          <div class="os-project-list">
-            {{#each monthlyOSProjects as monthlyOSProject}}
-                <input id="{{osProjectRef._id}}"
-                       type="checkbox"
-                       {{#if monthlyClientProjectsOSProjects.has(monthlyOSProject) }}checked{{/if}}
-                       value="{{osProjectRef.value.name}}"
-                       ($click)="toggleUseProject(monthlyClientProjectsOSProjects, monthlyOSProject)"
-                       {{#if isSaving}} disabled{{/if}}/>
-                <label for="{{osProjectRef._id}}"
-                       {{#if commissioned}} class="commissioned" {{/if}}>
-                  {{osProjectRef.value.name}}
-                </label>
-            {{/each}}
+        <button type="button" class="btn btn-link btn-sm" data-toggle="modal" data-target="#modal_{{id}}">
+          Edit OS Projects
+        </button>
+
+        {{! Modal }}
+        <div class="modal fade" id="modal_{{id}}" tabindex="-1" role="dialog" aria-hidden="true">
+          <div class="modal-dialog" role="document">
+            <div class="modal-content">
+              <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                  <span aria-hidden="true">&times;</span>
+                </button>
+                <h4 class="modal-title">Monthy Client OS Projects</h4>
+              </div>
+              <div class="modal-body">
+                <ul class="os-project-list">
+                {{#each monthlyOSProjects as monthlyOSProject}}
+                  <li>
+                    <input id="os_project_{{osProjectRef._id}}"
+                           type="checkbox"
+                           {{#if monthlyClientProjectsOSProjects.has(monthlyOSProject) }}checked{{/if}}
+                           value="{{osProjectRef.value.name}}"
+                           ($click)="toggleUseProject(monthlyClientProjectsOSProjects, monthlyOSProject)"
+                           {{#if isSaving}} disabled{{/if}}/>
+                    <label for="os_project_{{osProjectRef._id}}"
+                           {{#if commissioned}} class="commissioned" {{/if}}>
+                      {{osProjectRef.value.name}}
+                    </label>
+                  </li>
+                  {{/each}}
+                </ul>
+              </div>
+            </div>
           </div>
-        {{/if}}
+        </div>
+
+        {{! List of selected OS Projects}}
+        <ul class="selected-os-projects-list">
+          {{#each monthlyOSProjects as monthlyOSProject}}
+            {{#if monthlyClientProjectsOSProjects.has(monthlyOSProject)}}
+              <li>
+                {{osProjectRef.value.name}}
+                <button class="glyphicon glyphicon-remove btn btn-link btn-sm" ($click)="toggleUseProject(monthlyClientProjectsOSProjects, monthlyOSProject)"><span class="sr-only">Remove OS Project</span></button>
+              </li>
+            {{/if}}
+          {{/each}}
+        </ul>
+
       </td>
       <td>
          <span class="rate">${{getRate(monthlyClientProject)}}

--- a/public/components/client-projects/client-projects.stache
+++ b/public/components/client-projects/client-projects.stache
@@ -1,4 +1,5 @@
 {{#if contributionMonth.monthlyClientProjects.length}}
+{{#with contributionMonth}}
 <table class="table">
   <thead>
     <tr>
@@ -11,8 +12,9 @@
     </tr>
   </thead>
   <tbody>
-  {{#with contributionMonth}}
+
   {{#each monthlyClientProjects as monthlyClientProject}}
+    {{#if clientProjectRef.value}}
     <tr>
       <td>{{clientProjectRef.value.name}}</td>
       <td>
@@ -22,61 +24,13 @@
                {{#if isSaving}} disabled {{/if}}/>
       </td>
       <td class="os-projects-cell">
-        {{! Count of commissioned projects }}
-        {{commissionedMonthlyOSProjectsCountFor(monthlyClientProject)}} / {{monthlyOSProjects.commissioned.length}}
-        +
-        {{! Count of uncommisioned projects }}
-        {{uncommissionedMonthlyOSProjectsCountFor(monthlyClientProject)}}
-
-        {{! Toggle of OS projects }}
-        <button type="button" class="btn btn-link btn-sm" data-toggle="modal" data-target="#modal_{{id}}">
-          Edit OS Projects
+        <button type="button" class="btn btn-link btn-sm" data-toggle="modal" data-target="#os-project-modal" ($click)="setSelectedClientProject(monthlyClientProject)" >
+          {{! Count of commissioned projects }}
+          {{commissionedMonthlyOSProjectsCountFor(monthlyClientProject)}} / {{monthlyOSProjects.commissioned.length}}
+          +
+          {{! Count of uncommisioned projects }}
+          {{uncommissionedMonthlyOSProjectsCountFor(monthlyClientProject)}}
         </button>
-
-        {{! Modal }}
-        <div class="modal fade" id="modal_{{id}}" tabindex="-1" role="dialog" aria-hidden="true">
-          <div class="modal-dialog" role="document">
-            <div class="modal-content">
-              <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                  <span aria-hidden="true">&times;</span>
-                </button>
-                <h4 class="modal-title">Monthy Client OS Projects</h4>
-              </div>
-              <div class="modal-body">
-                <ul class="os-project-list">
-                {{#each monthlyOSProjects as monthlyOSProject}}
-                  <li>
-                    <input id="os_project_{{osProjectRef._id}}"
-                           type="checkbox"
-                           {{#if monthlyClientProjectsOSProjects.has(monthlyOSProject) }}checked{{/if}}
-                           value="{{osProjectRef.value.name}}"
-                           ($click)="toggleUseProject(monthlyClientProjectsOSProjects, monthlyOSProject)"
-                           {{#if isSaving}} disabled{{/if}}/>
-                    <label for="os_project_{{osProjectRef._id}}"
-                           {{#if commissioned}} class="commissioned" {{/if}}>
-                      {{osProjectRef.value.name}}
-                    </label>
-                  </li>
-                  {{/each}}
-                </ul>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        {{! List of selected OS Projects}}
-        <ul class="selected-os-projects-list">
-          {{#each monthlyOSProjects as monthlyOSProject}}
-            {{#if monthlyClientProjectsOSProjects.has(monthlyOSProject)}}
-              <li>
-                {{osProjectRef.value.name}}
-                <button class="glyphicon glyphicon-remove btn btn-link btn-sm" ($click)="toggleUseProject(monthlyClientProjectsOSProjects, monthlyOSProject)"><span class="sr-only">Remove OS Project</span></button>
-              </li>
-            {{/if}}
-          {{/each}}
-        </ul>
-
       </td>
       <td>
          <span class="rate">${{getRate(monthlyClientProject)}}
@@ -90,10 +44,14 @@
         </button>
       </td>
     </tr>
+    {{/if}}
   {{/each}}
-  {{/with}}
   </tbody>
 </table>
+{{/with}}
+
+{{! Partial defined in the view-model }}
+{{>os-projects-modal}}
 {{/if}}
 
 {{#if isAddingClients}}

--- a/public/components/client-projects/client-projects.stache
+++ b/public/components/client-projects/client-projects.stache
@@ -1,5 +1,4 @@
 {{#if contributionMonth.monthlyClientProjects.length}}
-{{#with contributionMonth}}
 <table class="table">
   <thead>
     <tr>
@@ -12,7 +11,7 @@
     </tr>
   </thead>
   <tbody>
-
+  {{#with contributionMonth}}
   {{#each monthlyClientProjects as monthlyClientProject}}
     {{#if clientProjectRef.value}}
     <tr>
@@ -46,12 +45,12 @@
     </tr>
     {{/if}}
   {{/each}}
+  {{/with}}
   </tbody>
 </table>
-{{/with}}
 
-{{! Partial defined in the view-model }}
-{{>os-projects-modal}}
+<can-import from="./client-projects-os-projects-modal.stache" {^@value}="@*osProjectsModal" />
+{{>*osProjectsModal}}
 {{/if}}
 
 {{#if isAddingClients}}

--- a/public/components/os-projects/os-projects.stache
+++ b/public/components/os-projects/os-projects.stache
@@ -11,6 +11,7 @@
   </thead>
   <tbody>
   {{#each contributionMonth.monthlyOSProjects as monthlyOSProject}}
+    {{#if osProjectRef.value}}
     <tr>
       <td>{{osProjectRef.value.name}}</td>
       <td>
@@ -36,6 +37,7 @@
         </button>
       </td>
     </tr>
+    {{/if}}
   {{/each}}
   </tbody>
 </table>

--- a/public/components/select-contribution-month/select-contribution-month.js
+++ b/public/components/select-contribution-month/select-contribution-month.js
@@ -1,5 +1,4 @@
 import moment from 'moment';
-import stache from 'can-stache';
 import Component from 'can-component';
 import DefineMap from 'can-define/map/';
 import './select-contribution-month.less';
@@ -26,8 +25,9 @@ export const ViewModel = DefineMap.extend({
         new ContributionMonth(last).save((newContributionMonth) => {
           setVal(newContributionMonth._id);
         });
+        
       } else {
-        return newVal;
+        setVal(newVal);
       }
     }
   },

--- a/public/components/select-contribution-month/select-contribution-month.js
+++ b/public/components/select-contribution-month/select-contribution-month.js
@@ -1,4 +1,5 @@
 import moment from 'moment';
+import stache from 'can-stache';
 import Component from 'can-component';
 import DefineMap from 'can-define/map/';
 import './select-contribution-month.less';
@@ -25,9 +26,8 @@ export const ViewModel = DefineMap.extend({
         new ContributionMonth(last).save((newContributionMonth) => {
           setVal(newContributionMonth._id);
         });
-        
       } else {
-        setVal(newVal);
+        return newVal;
       }
     }
   },


### PR DESCRIPTION
Closes #208 

I went through several iterations and had to settle on the modal.

- Semantic UI didn't work. I tried both Marshall's [semantic-ui-dropdown-canjs](https://github.com/icanjs/semantic-ui-dropdown-canjs) and vanilla Semantic UI - to no avail on either. Didn't want to spend cycles on _why_.
- Bootstrap Tooltips only work on :hover
- [Bootstrap Popovers](http://getbootstrap.com/javascript/#live-demo-1) aren't good with interactive content as there's no "click outside" to close popovers without doing [stuff like this](http://stackoverflow.com/questions/11703093/how-to-dismiss-a-twitter-bootstrap-popover-by-clicking-outside). You have to click on the button to both open **and close** the popover, which was bad UX even for me knowing this limitation.  

![os-project-select](https://cloud.githubusercontent.com/assets/514040/21622698/12a7fd9a-d1bc-11e6-8a3b-8faa97238604.gif)
