### PR TITLE
181 first user admin

### DIFF
--- a/src/services/user/hooks/index.js
+++ b/src/services/user/hooks/index.js
@@ -2,12 +2,13 @@
 
 const globalHooks = require('../../../hooks');
 const hooks = require('feathers-hooks');
+const makeFirstAdmin = require('./make-first-admin');
 
 exports.before = {
   all: [],
   find: [],
   get: [],
-  create: [],
+  create: [makeFirstAdmin()],
   update: [],
   patch: [],
   remove: []

--- a/src/services/user/hooks/make-first-admin.js
+++ b/src/services/user/hooks/make-first-admin.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const errors = require('feathers-errors');
+const denodeify = require('denodeify');
+
+/**
+ * This hook will check to see if any admins exist in the database.
+ * If not, the current user will be considered an admin.
+ */
+
+// If we have an admin, there's no sense checking in the future.
+let ADMIN_EXISTS = false;
+
+module.exports = () => {
+	return function (hook) {
+		if (!ADMIN_EXISTS) {
+			let user = hook.data;
+
+			if (!user.isAdmin) {
+
+				const User = hook.app.service('/api/users').Model;
+				const findUser = denodeify(User.findOne.bind(User));
+
+				return findUser({
+					isAdmin: true
+				}).then(result => {
+					if (!result) {
+						user.isAdmin = true;
+					}
+					ADMIN_EXISTS = true;
+					return hook;
+				});
+			}
+			ADMIN_EXISTS = true;
+		}
+		return Promise.resolve(hook);
+	};
+};

--- a/test/services/user/index.test.js
+++ b/test/services/user/index.test.js
@@ -2,9 +2,51 @@
 
 const assert = require('assert');
 const app = require('../../../src/app');
+const makeFirstAdmin = require('../../../src/services/user/hooks/make-first-admin');
+
+const makeHookObj = (method, data) => {
+	return {
+		method,
+		app,
+		data
+	};
+};
 
 describe('user service', function() {
-  it('registered the users service', () => {
-    assert.ok(app.service('/api/users'));
-  });
+	it('registered the users service', () => {
+		assert.ok(app.service('/api/users'));
+	});
+
+	it('Sets new user to an admin if one does not yet exist.', function () {
+		const User = app.service('/api/users').Model;
+		const oldFindOne = User.findOne;
+		const hookObj = makeHookObj('create', { isAdmin: false });
+		const hook = makeFirstAdmin();
+
+		User.findOne = function (params, cb) {
+			cb(null, null);	
+		};
+
+		// mocha lets us return a promise
+		return hook(hookObj).then(result => {
+			assert.ok(result.data.isAdmin, 'User should be an admin');
+		});
+	});
+
+	it('Does not set user to admin if one already exists', function () {
+		const User = app.service('/api/users').Model;
+		const oldFindOne = User.findOne;
+		const hookObj = makeHookObj('create', { isAdmin: false });
+		const hook = makeFirstAdmin();
+
+		User.findOne = function (params, cb) {
+			// Mimicks finding a user in db where isAdmin: true
+			cb(null, { isAdmin: true });	
+		};
+
+		// mocha lets us return a promise
+		return hook(hookObj).then(result => {
+			assert.ok(result.data.isAdmin === false, 'User should NOT be admin');
+		});
+	});
 });


### PR DESCRIPTION
This ensures the first non-admin user created will be an admin. If an admin already exists in the db, this will not work.

Also this was built on top of #241 (the `isAdmin` field for users). Please make sure that PR is merged first.