### PR TITLE
removed database.config, use config object instead #250

### DIFF
--- a/database.json
+++ b/database.json
@@ -1,7 +1,0 @@
-{
-  "dev": "mongodb://localhost:27017/bitcentive",
-  "production": {
-  	"ENV": "MONGODB_URI",
-  	"driver": "mongodb"
-  }
-}

--- a/migrate.js
+++ b/migrate.js
@@ -19,7 +19,13 @@
 const DBMigrate = require('db-migrate');
 const mongoose = require('mongoose');
 
-const options = {};
+const options = {
+	// To avoid having an additional config file (database.json):
+	config: {
+		"dev": require('./config/default.json').mongodb,
+		"production": { "ENV": require('./config/custom-environment-variables.json').mongodb }
+	}
+};
 
 // Travis runs db-migrate without passing NODE_ENV
 options.env = process.env.NODE_ENV


### PR DESCRIPTION
Since the format of `db-migrate` config and Feathers config are different, we use a `configObject` for `db-migrate` manually grabbing `mongodb` string from `config/*`.