### PR TITLE
Update mongoose and useNewUrlParser

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "feathers-mongoose": "^3.6.1",
     "feathers-rest": "^1.5.2",
     "feathers-socketio": "^1.4.2",
-    "mongoose": "^4.7.0",
+    "mongoose": "^5.2.2",
     "passport": "^0.3.2",
     "passport-github": "^1.1.0",
     "passport-github-token": "^2.1.0",

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -13,7 +13,7 @@ module.exports = function() {
   const app = this;
 
   if (process.env.TESTING !== 'true'){
-    mongoose.connect(app.get('mongodb'));
+    mongoose.connect(app.get('mongodb'), { useNewUrlParser: true });
   }
   mongoose.Promise = global.Promise;
 


### PR DESCRIPTION
Upgrading to latest mongoose version fixes that warning:

  - DeprecationWarning: `open()` is deprecated in mongoose >= 4.11.0, use `openUri()` instead, or set the `useMongoClient` option if using `connect()` or `createConnection()`. See http://mongoosejs.com/docs/4.x/docs/connections.html#use-mongo-client

Without connecting using `useNewUrlParser` there would be this new warning:

  - DeprecationWarning: current URL string parser is deprecated, and will be removed in a future version. To use the new parser, pass option { useNewUrlParser: true } to MongoClient.connect.

Upgrading to latest mongoose and using `useNewUrlParser` eliminates any warnings from showing when running `npm run develop` for this project.