### PR TITLE
Add no-zone to done-autorender in main

### DIFF
--- a/public/package.json
+++ b/public/package.json
@@ -26,7 +26,6 @@
     "JS"
   ],
   "steal": {
-    "main": "bitcentive/index.stache!done-autorender",
     "configDependencies": [
       "node_modules/can-zone/register"
     ],

--- a/public/package.json
+++ b/public/package.json
@@ -17,7 +17,7 @@
     "deploy": "firebase deploy --only hosting",
     "deploy:ci": "firebase deploy --only hosting --token \"$FIREBASE_TOKEN\""
   },
-  "main": "bitcentive/index.stache!done-autorender",
+  "main": "bitcentive/index.stache!done-autorender/no-zone",
   "files": [
     "."
   ],


### PR DESCRIPTION
Without `no-zone` live-reload (upon, for example, a style change) causes can-zone timeout errors:

![image](https://user-images.githubusercontent.com/990216/42542201-5d699380-846b-11e8-9954-28844b80dead.png)