### PR TITLE
Totals bug and more footers

### DIFF
--- a/public/components/page-dashboard/client-projects/client-projects.less
+++ b/public/components/page-dashboard/client-projects/client-projects.less
@@ -1,6 +1,13 @@
 bit-client-projects {
 	display: block;
 
+	.table > tfoot > tr {
+		> th, > td {
+			background: #efe;
+			border-top-width: 2px;
+		}
+	}
+
 	.hours-input {
 		width: 80px;
 	}

--- a/public/components/page-dashboard/client-projects/client-projects.stache
+++ b/public/components/page-dashboard/client-projects/client-projects.stache
@@ -51,6 +51,16 @@
 			{{/ if }}
 		{{/ each }}
 		</tbody>
+		<tfoot>
+      <tr>
+        <td class="total">Total</td>
+        <td>&nbsp;</td>
+        <td>&nbsp;</td>
+        <td>{{ formatDollarAmount(scope.vm.contributionMonth.sumRatesAcrossMonthlyProjects()) }}</td>
+        <td>{{ formatDollarAmount(scope.vm.contributionMonth.sumTotalsAcrossMonthlyProjects()) }}</td>
+        <td>&nbsp;</td>
+      </tr>
+		</tfoot>
 	</table>
 
 	<can-import from="./client-projects-os-projects-modal.stache" value:to="scope.vars.osProjectsModal" />

--- a/public/components/page-dashboard/os-projects/os-projects.js
+++ b/public/components/page-dashboard/os-projects/os-projects.js
@@ -81,6 +81,43 @@ export const ViewModel = DefineMap.extend({
     const osProject = this.osProjectPointsMap[monthlyOSProject.osProjectRef._id];
     return (osProject && osProject.totalPoints) || 0;
   },
+	sumOSProjectSignifances() {
+		let sum = 0;
+
+    this.contributionMonth.monthlyOSProjects.forEach(project => {
+			if (project.osProjectRef.value) {
+			  sum += project.significance;
+			}
+		});
+
+		return sum;
+	},
+	avgOSProjectSignifances() {
+		return (this.sumOSProjectSignifances() / this.contributionMonth.monthlyOSProjects.length).toFixed(2);
+	},
+  sumPointsForMonthlyProjects() {
+		var sum = 0;
+
+		for (const id in this.osProjectPointsMap) {
+      sum += this.osProjectPointsMap[id].totalPoints || 0;
+		}
+
+		return sum.toFixed(4);
+  },
+  avgTotalDollarsPerPointForOSProjects() {
+		let points = 0;
+		let dollars = 0;
+    let projectCount = this.contributionMonth.monthlyOSProjects.length || 1;
+
+    this.contributionMonth.monthlyOSProjects.forEach(project => {
+			if (project.osProjectRef.value) {
+			  dollars += project.getTotal();
+			  points += this.getPointTotalForOSProject(project);
+			}
+		});
+
+    return points ? (dollars / points) : dollars;
+  },
   getTotalDollarsPerPointForOSProject(monthlyOSProject) {
     const points = this.getPointTotalForOSProject(monthlyOSProject);
     const dollars = monthlyOSProject.getTotal();

--- a/public/components/page-dashboard/os-projects/os-projects.less
+++ b/public/components/page-dashboard/os-projects/os-projects.less
@@ -1,6 +1,13 @@
 os-projects {
 	display: block;
 
+	.table > tfoot > tr {
+		> th, > td {
+			background: #efe;
+			border-top-width: 2px;
+		}
+	}
+
   .significance-input {
     width: 80px;
   }

--- a/public/components/page-dashboard/os-projects/os-projects.stache
+++ b/public/components/page-dashboard/os-projects/os-projects.stache
@@ -55,6 +55,20 @@
 			{{/ if }}
 		{{/ each }}
 		</tbody>
+		<tfoot>
+			<tr>
+				<td>Total/Avg</td>
+				<td>
+					{{ scope.vm.sumOSProjectSignifances() }}
+					(Avg {{ scope.vm.avgOSProjectSignifances() }})
+				</td>
+				<td>&nbsp;</td>
+				<td>{{ formatDollarAmount(scope.vm.contributionMonth.calculations.totalDollarForAllClientProjects) }}</td>
+				<td>{{ scope.vm.sumPointsForMonthlyProjects() }}</td>
+				<td>Avg {{ formatDollarAmount(scope.vm.avgTotalDollarsPerPointForOSProjects()) }}</td>
+				<td>&nbsp;</td>
+			</tr>
+		</tfoot>
 	</table>
 {{/ if }}
 

--- a/public/models/contribution-month/contribution-month.js
+++ b/public/models/contribution-month/contribution-month.js
@@ -84,17 +84,16 @@ var ContributionMonth = DefineMap.extend("ContributionMonth", { seal: false }, {
 	  get: function() {
 		let total = 0;
 
-		this.monthlyOSProjects.forEach( osProject => {
-			if (osProject.commissioned) {
+			this.monthlyOSProjects.forEach( osProject => {
 				const totalAmountForOSProject = this.calculations.osProjects[osProject.osProjectRef._id];
+
 				if (totalAmountForOSProject !== undefined){
 					total += totalAmountForOSProject;
 				}
-			}
-		});
+			});
 
 		return total;
-	  }
+		}
 	},
 	calculations: {
 		get: function() {

--- a/public/models/contribution-month/contribution-month.js
+++ b/public/models/contribution-month/contribution-month.js
@@ -288,6 +288,24 @@ var ContributionMonth = DefineMap.extend("ContributionMonth", { seal: false }, {
 		return 0;
 
 	},
+	sumRatesAcrossMonthlyProjects: function() {
+		var sum = 0;
+
+		for (const id in this.calculations.clientProjects) {
+			sum += this.calculations.clientProjects[id].rate;
+		}
+
+		return sum;
+	},
+	sumTotalsAcrossMonthlyProjects: function() {
+		var sum = 0;
+
+		for (const id in this.calculations.clientProjects) {
+			sum += this.calculations.clientProjects[id].totalAmount || 0;
+		}
+
+		return sum;
+	},
 
 	addContribution(newContribution) {
 		this.monthlyContributions.push(newContribution);

--- a/public/models/contribution-month/monthly-os-project.js
+++ b/public/models/contribution-month/monthly-os-project.js
@@ -6,7 +6,7 @@ import ContributionMonth from "./contribution-month";
 import OSProject from "../os-project";
 
 const MonthlyOSProject = DefineMap.extend("MonthlyOSProject", { seal: false }, {
-  _id: {type: "string", identity: true},
+  _id: {type: "string"},
   significance: "number",
   commissioned: "boolean",
   osProjectRef: OSProject.Ref,


### PR DESCRIPTION
There were two bugs:
- Uncommissioned projects weren't included in the overall payouts total, though they _were_ included in the leftmost "Totals" column, which was inconsistent.
- Months that were copied over had the same ID as previous months, which lead to the OS Projects table not being updated when switching months.

I've also added table footers to make the tables easier to read.

@justinbmeyer where would I test this? Also, do _I_ deploy it?
