### PR TITLE
fix: remove identities from intermediate models

### DIFF
--- a/public/models/contribution-month/monthly-client-project.js
+++ b/public/models/contribution-month/monthly-client-project.js
@@ -4,7 +4,7 @@ import MonthlyClientProjectOsProjectList from "./monthly-client-project-os-proje
 import ClientProject from "../client-project";
 
 const MonthlyClientProject = DefineMap.extend( "MonthlyClientProject", { seal: false }, {
-  _id: {type: "string", identity: true},
+  _id: {type: "string"},
   clientProjectRef: ClientProject.Ref,
   hours: "number",
   monthlyClientProjectsOSProjects: {

--- a/public/models/contribution-month/monthly-contribution.js
+++ b/public/models/contribution-month/monthly-contribution.js
@@ -4,7 +4,7 @@ import OSProject from "../os-project";
 import Contributor from "../contributor";
 
 const MonthlyContribution = DefineMap.extend( "MonthlyContribution", { seal: false }, {
-  _id: {type: "string", identity: true},
+  _id: {type: "string"},
   contributorRef: Contributor.Ref,
   osProjectRef: OSProject.Ref,
   description: "string",

--- a/public/models/contribution-month/monthly-contributor.js
+++ b/public/models/contribution-month/monthly-contributor.js
@@ -4,7 +4,7 @@ import OSProject from "../os-project";
 import Contributor from "../contributor";
 
 const MonthlyContributor = DefineMap.extend( "MonthlyContributor", { seal: false }, {
-  _id: {type: "string", identity: true},
+  _id: {type: "string"},
   contributorRef: Contributor.Ref,
 });
 


### PR DESCRIPTION
The data for these intermediate models don't have unique id's so when the month changes the list is not refreshed within the #each loop.

https://github.com/donejs/bitcentive/issues/367