### PR TITLE
fix: use the current selected month to base the calculations from

### DIFF
--- a/public/components/page-dashboard/payouts/payouts_test.js
+++ b/public/components/page-dashboard/payouts/payouts_test.js
@@ -18,8 +18,8 @@ QUnit.test('viewModel.osProjectContributionsMap', function(assert){
   ContributionMonth.get("1").then(month => {
     vm = new ViewModel({ contributionMonth: month });
     vm.on('contributionMonths', () => {
-      QUnit.equal(vm.contributionMonths.osProjectContributionsMap(month)['2-DoneJS'].contributors['2-KyleGifford'].points, 3, 'has a contributor for DoneJS');
-      QUnit.equal(vm.contributionMonths.osProjectContributionsMap(month)['2-DoneJS'].totalPoints, 8, 'has totalPoints for DoneJS as 6');
+      QUnit.equal(vm.contributionMonths.osProjectContributionsMap(month)['2-DoneJS'].contributors['2-KyleGifford'].points, 13, 'has a contributor for DoneJS');
+      QUnit.equal(vm.contributionMonths.osProjectContributionsMap(month)['2-DoneJS'].totalPoints, 33, 'has totalPoints for DoneJS as 6');
       done();
     });
   });
@@ -32,8 +32,21 @@ QUnit.test('viewModel.osProjectContributionsMap', function (assert) {
   ContributionMonth.get("3").then(month => {
     vm = new ViewModel({ contributionMonth: month });
     vm.on('contributionMonths', () => {
-      QUnit.equal(vm.contributionMonths.osProjectContributionsMap(month)['1-CanJS'].contributors['1-JustinMeyer'].points, 17.5, 'has a contributor for CanJS');
-      QUnit.equal(vm.contributionMonths.osProjectContributionsMap(month)['1-CanJS'].totalPoints, 70, 'has totalPoints for CanJS as 70');
+      QUnit.equal(vm.contributionMonths.osProjectContributionsMap(month)['1-CanJS'].contributors['1-JustinMeyer'].points, 25, 'has a contributor for CanJS');
+      QUnit.equal(vm.contributionMonths.osProjectContributionsMap(month)['1-CanJS'].totalPoints, 100, 'has totalPoints for CanJS as 100');
+      done();
+    });
+  });
+});
+
+QUnit.test('viewModel.osProjectContributionsMap decay is based on month being viewed', function (assert) {
+  let done = assert.async();
+  let vm;
+  ContributionMonth.get("0").then(month => {
+    vm = new ViewModel({ contributionMonth: month });
+    vm.on('contributionMonths', () => {
+      QUnit.equal(vm.contributionMonths.osProjectContributionsMap(month)['1-CanJS'].contributors['1-JustinMeyer'].points, 4, 'has a contributor for CanJS');
+      QUnit.equal(vm.contributionMonths.osProjectContributionsMap(month)['1-CanJS'].totalPoints, 8, 'has totalPoints for CanJS as 100');
       done();
     });
   });

--- a/public/models/contribution-month/contribution-month.js
+++ b/public/models/contribution-month/contribution-month.js
@@ -332,13 +332,12 @@ ContributionMonth.List = DefineList.extend("ContributionMonthList", {
 		//console.log("calculations ------- \n");
 		//can.queues.logStack();
 		var osProjectContributionsMap = {};
-		const today = new Date().getTime();
 		this.forEach(contributionMonth => {
 			if (moment(contributionMonth.date).isBefore(moment(currentContributionMonth.date).add(1, 'day'))) {
 				contributionMonth.monthlyContributions.forEach(monthlyContribution => {
 					if (currentContributionMonth.contributorsMap[monthlyContribution.contributorRef._id]) {
 						// Impliment decay
-						const monthsAgo = (today - contributionMonth.date.getTime()) / oneMonth;
+						const monthsAgo = (currentContributionMonth.date.getTime() - contributionMonth.date.getTime()) / oneMonth;
 						const decayFactor = Math.floor(monthsAgo / monthsUntilDecay);
 						let points = monthlyContribution.points;
 

--- a/public/models/contribution-month/test/contribution-month-list_test.js
+++ b/public/models/contribution-month/test/contribution-month-list_test.js
@@ -39,7 +39,7 @@ QUnit.test("ContributionMonth.getList() works", function(assert) {
 });
 
 QUnit.test('.getTotalForAllPayoutsForContributor', assert => {
-	const amounts = [ 0, 87.5, 65.625, 87.5, 68.75 ];
+	const amounts = [ 175, 91.66666666666667, 65.625, 87.5, 68.75 ];
 
 	let done = assert.async();
 	ContributionMonth.getList({}).then(contributionMonths => {
@@ -57,7 +57,7 @@ QUnit.test('.getTotalForAllPayoutsForContributor', assert => {
 });
 
 QUnit.test('.getOSProjectPayoutTotal', function(assert) {
-	const amounts = [ 0, 87.5, 65.625, 87.5, 68.75 ];
+	const amounts = [ 175, 91.66666666666667, 65.625, 87.5, 68.75 ];
 
 	let done = assert.async();
 	ContributionMonth.getList({}).then(function(contributionMonths) {
@@ -78,8 +78,8 @@ QUnit.test('.getOSProjectPayoutTotal', function(assert) {
 
 QUnit.test('.getOwnershipPercentageForContributor', function(assert) {
 	const amounts = [
-		[ 0, 0 ],
-		[ 0.25, 0.75, 0 ],
+		[ 0.5, 0.5 ],
+		[ 0.2619047619047619, 0.7380952380952381, 0 ],
 		[ 0.1875, 0.5625, 0.25 ],
 		[ 0.25, 0.75 ],
 		[ 0.19642857142857142, 0.5892857142857143, 0.21428571428571427 ]


### PR DESCRIPTION
This is for when you are viewing December 2018 and the actual current month is April 2019. The calculations for the payouts will be based on the month being December 2018, this will show the correct points and $ for that point in time.